### PR TITLE
Remove CUDA toolkit version dependency.

### DIFF
--- a/condarecipe/meta.yaml
+++ b/condarecipe/meta.yaml
@@ -7,28 +7,30 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER|int }}
+  script_env:
+    - LD_LIBRARY_PATH # pass cuda libs through for docker builds
 
 requirements:
   build:
     - python
     - numpy x.x
     - numba
-    - cffi
   run:
     - python
     - numpy x.x
     - numba
-    - cudatoolkit 7.5
+    - cudatoolkit
     - libgfortran     [linux64]
-    - pyculib_sorting 1.0.0
+    - pyculib_sorting 1.0.*
     - cffi
     - scipy
 
 test:
   requires:
-    - pytest
     - scipy
+    - cudatoolkit {{ environ.get('CUDATOOLKIT_VERSION', 7.5) }}
   imports:
     - pyculib
   commands:
+    - numba -s
     - python -m unittest -v pyculib

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,12 @@
 Release notes
 =============
 
+Version 1.0.2
+=============
+
+Packaging fixes, remove fixed version of CUDA toolkit. No functional change.
+
+
 Version 1.0.1
 =============
 


### PR DESCRIPTION
This:
* Removes the CUDA toolkit v7.5 dependency
* Enables CUDA toolkit version testing via an env var